### PR TITLE
Force bytes to str conversion

### DIFF
--- a/lib/evernote/edam/notestore/ttypes.py
+++ b/lib/evernote/edam/notestore/ttypes.py
@@ -1192,7 +1192,9 @@ class NoteFilter(object):
             oprot.writeFieldEnd()
         if self.words is not None:
             oprot.writeFieldBegin('words', TType.STRING, 3)
-            oprot.writeString(self.words.encode('utf-8') if sys.version_info[0] == 2 else self.words)
+            if isinstance(self.words, bytes):
+                self.words = self.words.decode('utf-8')
+            oprot.writeString(self.words)
             oprot.writeFieldEnd()
         if self.notebookGuid is not None:
             oprot.writeFieldBegin('notebookGuid', TType.STRING, 4)


### PR DESCRIPTION
Somehow `self.words` sometimes(or everytime) comes as `bytes`, like `b'Files'`

Code in `evernote/lib/evernote/edam/notestore/ttypes.py:1195`, since we use Py3 in our project, from this `oprot.writeString(self.words.encode('utf-8') if sys.version_info[0] == 2 else self.words)` will  be `oprot.writeString(self.words)`

After there will be call of `thrift.compat.str_to_binary`

```
    def writeString(self, str_val):
        self.writeBinary(str_to_binary(str_val))
```

And then `thrift/compat.py:39`:
```
    def str_to_binary(str_val):
        return bytes(str_val, 'utf8')
```

And it's fail here, `since. str_val` is already `bytes` type.

Solution - convert bytes into str, and then `str_to_binary` will not rise an error.